### PR TITLE
Listar intenciones + Refactor + Tests

### DIFF
--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/model/Intention.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/model/Intention.kt
@@ -11,9 +11,6 @@ class Intention(
     val cryptoactive: CryptoCurrencyEnum,
 
     @Column(nullable = false)
-    val symbol: String,
-
-    @Column(nullable = false)
     val amountOfCrypto: Double,
 
     @Column(nullable = false)
@@ -22,11 +19,8 @@ class Intention(
     @Column(nullable = false)
     val amountInPesos: Double,
 
-    @Column(nullable = false)
-    val nameUser: String,
-
-    @Column(nullable = false)
-    val surnameUser: String,
+    @ManyToOne(cascade = [CascadeType.ALL])
+    val user: User,
 
     @Column(nullable = false)
     val operation: OperationEnum,
@@ -41,9 +35,9 @@ class Intention(
     }
 
     private fun isValidCryptoactive(cryptoactive: CryptoCurrencyEnum): Boolean {
-        return cryptoactive in CryptoCurrencyEnum.values()
+        return cryptoactive in CryptoCurrencyEnum.entries.toTypedArray()
     }
     private fun isValidOperation(operation: OperationEnum): Boolean {
-        return operation in OperationEnum.values()
+        return operation in OperationEnum.entries.toTypedArray()
     }
 }

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/model/OperationEnum.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/model/OperationEnum.kt
@@ -2,5 +2,5 @@ package ar.edu.unq.desapp.grupoa.backenddesappapi.model
 
 enum class OperationEnum {
     BUY,
-    SALE
+    SELL
 }

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/model/exceptions/exceptionsIntention/UsernameIntentException.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/model/exceptions/exceptionsIntention/UsernameIntentException.kt
@@ -1,3 +1,4 @@
 package ar.edu.unq.desapp.grupoa.backenddesappapi.model.exceptions.exceptionsIntention
 
-class UsernameIntentException(nameUser: String, surnameUser: String) : Exception("Error: $nameUser $surnameUser is not registered to make a BUY/SELL Intent")
+class UsernameIntentException(userId: Long) :
+    Exception("Error: user with id $userId is not registered to make a BUY/SELL Intent")

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/persistence/IntentionRepository.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/persistence/IntentionRepository.kt
@@ -5,6 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface IntentionRepository : JpaRepository<Intention, Long> {
-    @Query("select case when count(u) > 0 then true else false end from User u where u.name = ?1 and u.surname = ?2")
-    fun existsNameUser(nameUser: String, surnameUser: String): Boolean
+    fun findAllByUserId(userId: Long): List<Intention>
 }

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/persistence/UserRepository.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/persistence/UserRepository.kt
@@ -6,13 +6,8 @@ import org.springframework.data.jpa.repository.Query
 
 interface UserRepository : JpaRepository<User, Long> {
 
-    @Query("select count(u) = 1 from User u where u.email = ?1")
     fun existsByEmail(email: String): Boolean
-
-    @Query("select count(u) = 1 from User u where u.cvu = ?1")
-    fun existsByCVU(cvu: String): Boolean
-
-    @Query("select count(u) = 1 from User u where u.walletAddress = ?1")
-    fun existsByWallet(wallet: String): Boolean
+    fun existsByCvu(cvu: String): Boolean
+    fun existsByWalletAddress(wallet: String): Boolean
 
 }

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/service/IntentionService.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/service/IntentionService.kt
@@ -1,9 +1,12 @@
 package ar.edu.unq.desapp.grupoa.backenddesappapi.service
 
+import ar.edu.unq.desapp.grupoa.backenddesappapi.model.CryptoCurrencyEnum
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.Intention
+import ar.edu.unq.desapp.grupoa.backenddesappapi.model.OperationEnum
 
 interface IntentionService {
-    fun createIntention(intention: Intention): Intention
+    fun createIntention(crypto: CryptoCurrencyEnum, quantity: Double, price: Double, userId: Long, operation: OperationEnum): Intention
+    fun listIntentionsForUser(userId: Long): List<Intention>
     fun getIntentionById(id: Long): Intention
     fun deleteAll()
 }

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/service/impl/CryptoCurrencyServiceImpl.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/service/impl/CryptoCurrencyServiceImpl.kt
@@ -1,6 +1,5 @@
 package ar.edu.unq.desapp.grupoa.backenddesappapi.service.impl
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.CryptoCurrencyEnum
-import ar.edu.unq.desapp.grupoa.backenddesappapi.persistence.UserRepository
 import ar.edu.unq.desapp.grupoa.backenddesappapi.service.CryptoService
 import ar.edu.unq.desapp.grupoa.backenddesappapi.service.integration.BinanceApi
 import org.springframework.beans.factory.annotation.Autowired
@@ -9,7 +8,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Service
-class CryptoCurrencyService : CryptoService {
+class CryptoCurrencyServiceImpl : CryptoService {
 
     @Autowired
     private lateinit var binanceApi: BinanceApi

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/service/impl/IntentionServiceImpl.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/service/impl/IntentionServiceImpl.kt
@@ -1,37 +1,65 @@
 package ar.edu.unq.desapp.grupoa.backenddesappapi.service.impl
 
+import ar.edu.unq.desapp.grupoa.backenddesappapi.model.CryptoCurrencyEnum
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.Intention
+import ar.edu.unq.desapp.grupoa.backenddesappapi.model.OperationEnum
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.exceptions.exceptionsIntention.ErrorCreatingIntention
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.exceptions.exceptionsIntention.InvalidCryptoactiveException
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.exceptions.exceptionsIntention.InvalidOperationException
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.exceptions.exceptionsIntention.UsernameIntentException
 import ar.edu.unq.desapp.grupoa.backenddesappapi.persistence.IntentionRepository
+import ar.edu.unq.desapp.grupoa.backenddesappapi.persistence.UserRepository
 import ar.edu.unq.desapp.grupoa.backenddesappapi.service.IntentionService
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional
 class IntentionServiceImpl : IntentionService {
     @Autowired
     private lateinit var intentionRepository: IntentionRepository
-    override fun createIntention(intention: Intention): Intention {
-        try{
-            intention.validateIntentionData()
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    override fun createIntention(
+        crypto: CryptoCurrencyEnum,
+        quantity: Double,
+        price: Double,
+        userId: Long,
+        operation: OperationEnum
+    ): Intention {
+        val user = userRepository.findById(userId).orElseThrow { UsernameIntentException(userId) }
+        val intention = Intention(
+            crypto,
+            quantity,
+            price,
+            quantity * price * 1085, // TODO: 1085 es un valor actual del dolar, habría que saberlo en el momento
+            user,
+            operation
+        )
+        try {
+            intention.validateIntentionData() // TODO: acá habría que validar que price no está fuera del margen del 10% en base a la cotización de la cripto
         } catch (ex: Throwable) {
             when (ex) {
                 is InvalidOperationException,
-                is InvalidCryptoactiveException,
-                is UsernameIntentException -> throw ErrorCreatingIntention(ex.message!!)
+                is InvalidCryptoactiveException -> throw ErrorCreatingIntention(ex.message!!)
+
                 else -> throw ex
             }
         }
-        if(!intentionRepository.existsNameUser(intention.nameUser, intention.surnameUser)) throw UsernameIntentException(intention.nameUser, intention.surnameUser)
         return intentionRepository.save(intention)
     }
 
+    override fun listIntentionsForUser(userId: Long): List<Intention> {
+        return intentionRepository.findAllByUserId(userId)
+    }
+
     override fun getIntentionById(id: Long): Intention {
-        return intentionRepository.findById(id).orElseThrow { EntityNotFoundException("Intention not found with id: $id") }
+        return intentionRepository.findById(id)
+            .orElseThrow { EntityNotFoundException("Intention not found with id: $id") }
     }
 
     override fun deleteAll() {

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/service/impl/UserServiceImpl.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/service/impl/UserServiceImpl.kt
@@ -7,9 +7,11 @@ import ar.edu.unq.desapp.grupoa.backenddesappapi.service.UserService
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class UserService: UserService {
+@Transactional
+class UserServiceImpl : UserService {
     @Autowired
     private lateinit var userRepository: UserRepository
 
@@ -27,12 +29,16 @@ class UserService: UserService {
                 is InvalidEmailException,
                 is BadAddressException,
                 is BadBankDataException -> throw ErrorCreatingUser(ex.message!!)
+
                 else -> throw ex
             }
         }
         if (userRepository.existsByEmail(user.email)) throw UserAlreadyRegisteredException("email", user.email)
-        if (userRepository.existsByCVU(user.cvu)) throw UserAlreadyRegisteredException("cvu", user.cvu)
-        if (userRepository.existsByWallet(user.walletAddress)) throw UserAlreadyRegisteredException("wallet", user.walletAddress)
+        if (userRepository.existsByCvu(user.cvu)) throw UserAlreadyRegisteredException("cvu", user.cvu)
+        if (userRepository.existsByWalletAddress(user.walletAddress)) throw UserAlreadyRegisteredException(
+            "wallet",
+            user.walletAddress
+        )
         return userRepository.save(user)
     }
 

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/webservice/CryptoCurrencyController.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/webservice/CryptoCurrencyController.kt
@@ -1,7 +1,7 @@
 package ar.edu.unq.desapp.grupoa.backenddesappapi.webservice
 
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.CryptoCurrencyEnum
-import ar.edu.unq.desapp.grupoa.backenddesappapi.service.impl.CryptoCurrencyService
+import ar.edu.unq.desapp.grupoa.backenddesappapi.service.CryptoService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 class CryptoCurrencyController {
 
     @Autowired
-    private lateinit var cryptoCurrencyService: CryptoCurrencyService
+    private lateinit var cryptoCurrencyService: CryptoService
 
     @GetMapping("/cryptoasset-quotes")
     fun showCryptoAssetQuotes(): ResponseEntity<Map<String, Float?>> {

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/webservice/IntentionController.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/webservice/IntentionController.kt
@@ -22,13 +22,20 @@ class IntentionController {
     private lateinit var intentionService: IntentionService
 
     @PostMapping("/create")
-    fun createIntention(@Valid @RequestBody intentionDto: IntentionDTO): ResponseEntity<String> {
+    fun createIntention(@Valid @RequestBody intentionDTO: IntentionDTO): ResponseEntity<String> {
         try {
-            intentionService.createIntention(intentionDto.toModel())
+            intentionService.createIntention(
+                intentionDTO.cryptoactive,
+                intentionDTO.amountOfCrypto,
+                intentionDTO.lastQuotation,
+                intentionDTO.userId,
+                intentionDTO.operation
+            )
         } catch (ex: Throwable) {
             when (ex) {
                 is ErrorCreatingIntention ->
-                    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Failed to create intention: ${ex.message}")
+                    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body("Failed to create intention: ${ex.message}")
             }
         }
         return ResponseEntity.status(HttpStatus.CREATED).body("Intention created successfully")

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/webservice/UserController.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/webservice/UserController.kt
@@ -2,10 +2,11 @@ package ar.edu.unq.desapp.grupoa.backenddesappapi.webservice
 
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.exceptions.ErrorCreatingUser
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.exceptions.UserAlreadyRegisteredException
+import ar.edu.unq.desapp.grupoa.backenddesappapi.service.UserService
 import ar.edu.unq.desapp.grupoa.backenddesappapi.webservice.dtos.UserDTO
-import ar.edu.unq.desapp.grupoa.backenddesappapi.service.impl.UserService
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -15,7 +16,10 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/users")
 @Tag(name = "Users", description = "Endpoint that manages users")
 @Validated
-class UserController (private val userService: UserService){
+class UserController {
+
+    @Autowired
+    private lateinit var userService: UserService
 
     @PostMapping("/register")
     fun register(@Valid @RequestBody userData: UserDTO): ResponseEntity<String> {
@@ -27,7 +31,8 @@ class UserController (private val userService: UserService){
                     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Something went wrong! ${ex.message}")
             }
         }
-        return ResponseEntity.status(HttpStatus.CREATED).body("Welcome ${userData.name} ${userData.surname}! You've been successfully registered.")
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body("Welcome ${userData.name} ${userData.surname}! You've been successfully registered.")
     }
 
 }

--- a/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/webservice/dtos/IntentionDTO.kt
+++ b/backend-desapp-api/src/main/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/webservice/dtos/IntentionDTO.kt
@@ -1,17 +1,9 @@
 package ar.edu.unq.desapp.grupoa.backenddesappapi.webservice.dtos
 
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.CryptoCurrencyEnum
-import ar.edu.unq.desapp.grupoa.backenddesappapi.model.Intention
 import ar.edu.unq.desapp.grupoa.backenddesappapi.model.OperationEnum
 
-data class IntentionDTO (val cryptoactive: CryptoCurrencyEnum, val symbol: String, val amountOfCrypto: Double,
-                         val lastQuotation: Double, val amountInPesos: Double, val nameUser: String,
-                         val surnameUser: String, val operation: OperationEnum
-) {
-    fun toModel(): Intention {
-        return Intention(cryptoactive = this.cryptoactive, symbol = this.symbol, amountOfCrypto = this.amountOfCrypto,
-            lastQuotation = this.lastQuotation, amountInPesos = this.amountInPesos, nameUser = this.nameUser, surnameUser = this.surnameUser,
-            operation = this.operation)
-    }
-}
-
+data class IntentionDTO(
+    val cryptoactive: CryptoCurrencyEnum, val amountOfCrypto: Double,
+    val lastQuotation: Double, val amountInPesos: Double, val userId: Long, val operation: OperationEnum
+)

--- a/backend-desapp-api/src/test/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/service/IntentionServiceTest.kt
+++ b/backend-desapp-api/src/test/kotlin/ar/edu/unq/desapp/grupoa/backenddesappapi/service/IntentionServiceTest.kt
@@ -1,0 +1,89 @@
+package ar.edu.unq.desapp.grupoa.backenddesappapi.service
+
+import ar.edu.unq.desapp.grupoa.backenddesappapi.model.CryptoCurrencyEnum
+import ar.edu.unq.desapp.grupoa.backenddesappapi.model.OperationEnum
+import ar.edu.unq.desapp.grupoa.backenddesappapi.model.User
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class IntentionServiceTest {
+
+    @Autowired
+    private lateinit var intentionService: IntentionService
+
+    @Autowired
+    private lateinit var userService: UserService
+
+    private lateinit var user: User
+
+    @BeforeEach
+    fun setUp() {
+        user = userService.createUser(
+            User(
+                "Satoshi",
+                "Nakamoto",
+                "satonaka@gmail.com",
+                "Fake Street 123",
+                "Security1234!",
+                "0011223344556677889911",
+                "01234567",
+                5.0,
+            )
+        )
+    }
+
+    @Test
+    fun listIntentionsForUserHaveTheUserId() {
+        val intention1 = intentionService.createIntention(
+            CryptoCurrencyEnum.ETHUSDT,
+            2.0,
+            3999.0,
+            user.id!!,
+            OperationEnum.BUY
+        )
+        val intention2 = intentionService.createIntention(
+            CryptoCurrencyEnum.ETHUSDT,
+            1.0,
+            4070.0,
+            user.id!!,
+            OperationEnum.SELL
+        )
+        val intention3 = intentionService.createIntention(
+            CryptoCurrencyEnum.ETHUSDT,
+            1.0,
+            4100.0,
+            user.id!!,
+            OperationEnum.SELL
+        )
+        val intentions = intentionService.listIntentionsForUser(user.id!!)
+
+        assertTrue(intentions.size == 3)
+        assertTrue(intentions.any { it.id == intention1.id && it.user.id == user.id })
+        assertTrue(intentions.any { it.id == intention2.id && it.user.id == user.id })
+        assertTrue(intentions.any { it.id == intention3.id && it.user.id == user.id })
+    }
+
+    @Test
+    fun listIntentionsForUserThatHasNoIntentionsReturnsEmptyList() {
+        assertTrue(intentionService.listIntentionsForUser(user.id!!).isEmpty())
+    }
+
+    @Test
+    fun listIntentionsWithNonexistentUserReturnsEmptyList() {
+        assertTrue(intentionService.listIntentionsForUser(999).isEmpty())
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        intentionService.deleteAll()
+        userService.deleteAll()
+    }
+}


### PR DESCRIPTION
En este PR estamos sumando varias cosas:

- En principio hay varios cambios de formato en los archivos (resultado de aplicar un reformat desde el IDE, no hace falta revisar esto, son mas cuestiones de indentación mas Kotlin-style).
- Hacemos un refactor en el modelo Intention, agregamos una n<->1 relation para los usuarios, ya que tiene mas sentido plantearlo asi que buscar nombres y apellidos en la base. Además de que se simplifican mucho las búsquedas y métodos del IntentionRepository.
- Cambiamos typo SALE por SELL en los tipos de operación.
- Simplificamos las queries del UserRepository con los named query methods de spring.
- Modificamos la firma del createIntention del IntentionService, en vez de recibir el modelo ahora recibimos los datos necesarios para crear una intención, y el service y modelo hacen las validaciones necesarias.
- Dejamos varios TODOs en la implementación del createIntention que es lo que falta según el enunciado (habría que testearlo también).

Cosas que faltan todavía:
- Crear el endpoint en el controller y sus tests.